### PR TITLE
the value in rcx is the next RIP

### DIFF
--- a/SysCall/syscall-2.md
+++ b/SysCall/syscall-2.md
@@ -248,7 +248,7 @@ sub	$(6*8), %rsp
 When a system call occurs from the user's application, general purpose registers have the following state:
 
 * `rax` - contains system call number; 
-* `rcx` - contains return address to the user space;
+* `rcx` - contains the next instruction pointer;
 * `r11` - contains register flags;
 * `rdi` - contains first argument of a system call handler;
 * `rsi` - contains second argument of a system call handler;


### PR DESCRIPTION
After syscall, rcx contains the next rip as defined in `linux/arch/x86_64/entry.S`
